### PR TITLE
Fix #5 for Code Analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,103 @@
+# WARNING: This Makefile is used only for code analysis and should not be used
+# for product builds.
+# DO NOT DELETE THIS LINE -- make depend uses it
+
+# Set the systype flag.
+SYSTYPE_FLAG = 
+
+# Set up compiler and its flags
+CC=gcc
+INCLUDES=-I. -I./glob
+CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONFIG_H -D HAVE_SYS_SIGLIST $(INCLUDES) 
+GMAKE_EXE=gmake
+LIBS=-ldl
+LDFLAGS=$(SYSTYPE_FLAG)
+
+# List of object files
+objects = alloca.o  \
+          ar.o \
+          arscan.o \
+          commands.o \
+          default.o \
+          dir.o \
+          expand.o \
+          file.o \
+          function.o \
+          getloadavg.o \
+          getopt1.o \
+          getopt.o \
+          guile.o \
+          hash.o \
+          implicit.o \
+          job.o \
+          load.o \
+          main.o \
+          misc.o \
+          output.o \
+          remake.o \
+          read.o \
+          remote-stub.o \
+          rule.o \
+          signame.o \
+          strcache.o \
+          tandem.o \
+          tandem_ext.o \
+          variable.o \
+          version.o \
+          vpath.o \
+          glob/glob.o \
+          glob/fnmatch.o
+
+# Link line
+$(GMAKE_EXE) : $(objects)
+	$(CC) $(LDFLAGS) -o $(GMAKE_EXE) $(objects) $(LIBS)
+
+default : $(GMAKE_EXE)
+
+# Compilation line
+%.o: %.c
+	$(CC) -c $(CFLAGS) -o $@ $<
+glob/%.o: glob/%.c
+	$(CC) -c $(CFLAGS) -o $@ $<
+
+# Dependency details
+alloca.o       : config.h
+ar.o           : makeint.h config.h signame.h filedef.h dep.h glob/fnmatch.h
+arscan.o       : makeint.h config.h signame.h 
+commands.o     : makeint.h config.h signame.h dep.h filedef.h variable.h job.h commands.h
+default.o      : makeint.h config.h signame.h rule.h dep.h filedef.h job.h commands.h variable.h
+dir.o          : makeint.h config.h signame.h glob/glob.h
+expand.o       : makeint.h config.h signame.h filedef.h job.h commands.h variable.h rule.h
+file.o         : makeint.h config.h signame.h dep.h filedef.h job.h commands.h variable.h
+function.o     : makeint.h config.h signame.h filedef.h variable.h dep.h job.h commands.h
+getloadavg.o   : config.h
+getopt1.o      : config.h getopt.h
+getopt.o       : config.h getopt.h
+guile.o        : makeint.h gnumake.h debug.h filedef.h dep.h variable.h
+hash.o         : makeint.h hash.h
+implicit.o     : makeint.h config.h signame.h rule.h dep.h filedef.h
+job.o          : makeint.h config.h signame.h job.h filedef.h commands.h variable.h
+load.o         : makeint.h #include debug.h filedef.h variable.h
+main.o         : ver.c makeint.h config.h signame.h dep.h filedef.h variable.h job.h commands.h getopt.h
+misc.o         : makeint.h config.h signame.h dep.h
+output.o       : makeint.h job.h output.h
+read.o         : makeint.h config.h signame.h filedef.h job.h commands.h dep.h
+remake.o       : makeint.h config.h signame.h dep.h filedef.h job.h commands.h variable.h rule.h glob/glob.h
+remote-stub.o  : makeint.h config.h signame.h filedef.h job.h commands.h
+rule.o         : makeint.h config.h signame.h dep.h filedef.h job.h commands.h variable.h rule.h
+signame.o      : config.h signame.h
+strcache.o     : makeint.h hash.h
+tandem.o       : makeint.h
+tandem_ext.o   : makeint.h
+variable.o     : makeint.h config.h signame.h dep.h filedef.h job.h commands.h variable.h
+version.o      : config.h
+vpath.o        : makeint.h config.h signame.h filedef.h variable.h
+glob/glob.o    : config.h glob/fnmatch.h glob/glob.h
+glob/fnmatch.o : config.h glob/fnmatch.h
+
+# Cleaning related.
+.PHONY : clean
+clean :
+	rm -f $(GMAKE_EXE) $(objects)
+
+clobber: clean

--- a/file.c
+++ b/file.c
@@ -17,8 +17,8 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include "makeint.h"
 
 #include <assert.h>
-#ifdef __TANDEM
 #include <time.h>
+#ifdef __TANDEM
 #include <stdlib.h>
 #include <unistd.h>
 #endif

--- a/glob/glob.c
+++ b/glob/glob.c
@@ -1361,3 +1361,9 @@ glob_in_dir (pattern, directory, flags, errfunc, pglob)
 }
 
 #endif  /* Not ELIDE_CODE.  */
+
+#ifdef __GNUC__
+/* In case this does not get defined. */
+#undef __alloca
+int __alloca(size_t len) { return malloc(len); }
+#endif

--- a/signame.c
+++ b/signame.c
@@ -40,7 +40,9 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 static const char *undoc;
 
+#ifndef HAVE_SYS_SIGLIST
 static const char *sys_siglist[NSIG];
+#endif
 
 /* Table of abbreviations for signals.  Note:  A given number can
    appear more than once with different abbreviations.  */
@@ -66,8 +68,10 @@ init_sig (int number, const char *abbrev, const char *name)
      the system headers, but... better safe than sorry.  We know, for
      example, that this isn't always true on VMS.  */
 
+#ifndef HAVE_SYS_SIGLIST
   if (number >= 0 && number < NSIG)
     sys_siglist[number] = name;
+#endif
 
   if (sig_table_nelts < SIG_TABLE_SIZE)
     {
@@ -83,9 +87,11 @@ signame_init (void)
 
   undoc = xstrdup (_("unknown signal"));
 
+#ifndef HAVE_SYS_SIGLIST
   /* Initialize signal names.  */
   for (i = 0; i < NSIG; i++)
     sys_siglist[i] = undoc;
+#endif
 
   /* Initialize signal names.  */
 #if defined (SIGHUP)

--- a/tandem.c
+++ b/tandem.c
@@ -1,8 +1,5 @@
 #ifdef __TANDEM
 #define NOLIST nolist
-#else
-#define NOLIST
-#endif
 #include <stdio.h> NOLIST
 #include <stdlib.h> NOLIST
 #include <string.h> NOLIST
@@ -690,6 +687,10 @@ int launch_proc(char *argv[], char *envp[])
    FILE_CLOSE_(filenum);
    return procrc;
 }
+
+#else
+static void noop(void) {}
+#endif /* __TANDEM */
 
 /*===========================================================================*/
 #pragma page "T0593 GUARDIAN GNU Make- standemc Change Descriptions"

--- a/tandem_ext.c
+++ b/tandem_ext.c
@@ -1,7 +1,6 @@
 #ifdef __TANDEM
 #define NOLIST nolist
 #define _XOPEN_SOURCE
-#endif
 #include <stdio.h> NOLIST
 #include <stdlib.h> NOLIST
 #include <string.h> NOLIST
@@ -105,6 +104,9 @@ int stat(const char *pathname, struct stat *st)
 
   return rc ? -1 : 0;
 }
+#else
+static void noop(void) {}
+#endif
 /*===========================================================================*/
 #pragma page "T0593 GUARDIAN GNU Make- stanfunc Change Descriptions"
 /*===========================================================================*/


### PR DESCRIPTION
This consists of modifications to the code to allow CodeQL to build. Some functions requiring `__TANDEM` and related definitions may not be scanned.