### PR TITLE
Using tag and committer date to compute VPROC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # for product builds.
 # DO NOT DELETE THIS LINE -- make depend uses it
 
+VPROC=$(shell sh ./version.sh)
+
 # Set the systype flag.
 SYSTYPE_FLAG = 
 
@@ -12,6 +14,8 @@ CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONF
 GMAKE_EXE=gmake
 LIBS=-ldl
 LDFLAGS=$(SYSTYPE_FLAG)
+
+.PHONY: version.o
 
 # List of object files
 objects = alloca.o  \
@@ -59,6 +63,9 @@ default : $(GMAKE_EXE)
 	$(CC) -c $(CFLAGS) -o $@ $<
 glob/%.o: glob/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+
+version.o: version.c
+	$(CC) -c $(CFLAGS) -DVPROC=$(VPROC) -o $@ $<
 
 # Dependency details
 alloca.o       : config.h

--- a/Makefile.NSE.OSS
+++ b/Makefile.NSE.OSS
@@ -1,5 +1,7 @@
 # DO NOT DELETE THIS LINE -- make depend uses it
 
+VPROC=$(shell sh ./version.sh)
+
 # Set the systype flag.
 SYSTYPE_FLAG = -Wsystype=guardian -Wtarget=tns/e
 
@@ -9,6 +11,8 @@ INCLUDES=-I. -I./glob -I/G/system/zsysdefs
 CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONFIG_H -Wextensions -g  -Wnowarn=1506,161 -O2 $(INCLUDES) 
 GMAKE_EXE=gmake
 LDFLAGS=$(SYSTYPE_FLAG) -lrld
+
+.PHONY: version.o
 
 # List of object files
 objects = alloca.o  \
@@ -56,6 +60,9 @@ default : $(GMAKE_EXE)
 	$(CC) -c $(CFLAGS) -o $@ $<
 glob/%.o: glob/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+
+version.o: version.c
+	$(CC) -c $(CFLAGS) -DVPROC=$(VPROC) -o $@ $<
 
 # Dependency details
 alloca.o       : config.h

--- a/Makefile.NSE.Win
+++ b/Makefile.NSE.Win
@@ -1,5 +1,7 @@
 # DO NOT DELETE THIS LINE -- make depend uses it
 
+VPROC=$(shell sh ./version.sh)
+
 # Set up environment to use product compiler.
 export COMP_ROOT=C:\Program Files (x86)\HPE NonStop\J06.21
 
@@ -12,6 +14,8 @@ INCLUDES=-I. -I./glob -I/G/system/zsysdefs
 CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONFIG_H -Wextensions -g  -Wnowarn=1506,161 -O2 $(INCLUDES) 
 GMAKE_EXE=gmake
 LDFLAGS=$(SYSTYPE_FLAG) -lrld
+
+.PHONY: version.o
 
 # List of object files
 objects = alloca.o  \
@@ -57,6 +61,9 @@ default : $(GMAKE_EXE)
 # Compilation line
 %.o: %.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+
+version.o: version.c
+	$(CC) -c $(CFLAGS) -DVPROC=$(VPROC) -o $@ $<
 
 # Dependency details
 alloca.o       : config.h

--- a/Makefile.NSX.OSS
+++ b/Makefile.NSX.OSS
@@ -1,5 +1,7 @@
 # DO NOT DELETE THIS LINE -- make depend uses it
 
+VPROC=$(shell sh ./version.sh)
+
 # Set the systype flag.
 SYSTYPE_FLAG = -Wsystype=guardian -Wtarget=tns/x
 
@@ -9,6 +11,8 @@ INCLUDES=-I. -I./glob -I/G/system/zsysdefs
 CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONFIG_H -Wextensions -g  -Wnowarn=1506,161 -O2 $(INCLUDES) 
 GMAKE_EXE=gmake
 LDFLAGS=$(SYSTYPE_FLAG) -lrld
+
+.PHONY: version.o
 
 # List of object files
 objects = alloca.o  \
@@ -56,6 +60,9 @@ default : $(GMAKE_EXE)
 	$(CC) -c $(CFLAGS) -o $@ $<
 glob/%.o: glob/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+
+version.o: version.c
+	$(CC) -c $(CFLAGS) -DVPROC=$(VPROC) -o $@ $<
 
 # Dependency details
 alloca.o       : config.h

--- a/Makefile.NSX.Win
+++ b/Makefile.NSX.Win
@@ -1,5 +1,7 @@
 # DO NOT DELETE THIS LINE -- make depend uses it
 
+VPROC=$(shell sh ./version.sh)
+
 # Set up environment to use product compiler.
 export COMP_ROOT=C:\Program Files (x86)\HPE NonStop\L16.05
 
@@ -12,6 +14,8 @@ INCLUDES=-I. -I./glob -I/G/system/zsysdefs
 CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONFIG_H -Wextensions -g  -Wnowarn=1506,161 -O2 $(INCLUDES) 
 GMAKE_EXE=gmake
 LDFLAGS=$(SYSTYPE_FLAG) -lrld
+
+.PHONY: version.o
 
 # List of object files
 objects = alloca.o  \
@@ -57,6 +61,9 @@ default : $(GMAKE_EXE)
 # Compilation line
 %.o: %.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+
+version.o: version.c
+	$(CC) -c $(CFLAGS) -DVPROC=$(VPROC) -o $@ $<
 
 # Dependency details
 alloca.o       : config.h

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #define MY_FEOK 0
 
 #ifdef __TANDEM
-#include "ver.c (VERSION_STRING, VERSION_GMAKE)"
+#include "ver.c (VERSION_STRING)"
 #include <cextdecs.h(OLDFILENAME_TO_FILENAME_)>
 /* #include <derror.h> NOLIST */
 #ifdef _OSS_HOST

--- a/makein
+++ b/makein
@@ -1,5 +1,7 @@
 # DO NOT DELETE THIS LINE -- make depend uses it
 
+VPROC=$(shell sh ./version.sh)
+
 # Set up environment to use product compiler.
 <PRODUCTE> export COMP_ROOT=C:\Program Files (x86)\HPE NonStop\J06.21
 <PRODUCTX> export COMP_ROOT=C:\Program Files (x86)\HPE NonStop\L17.02
@@ -14,6 +16,8 @@ INCLUDES=-I. -I./glob -I/G/system/zsysdefs
 CFLAGS=$(SYSTYPE_FLAG) -D INCLUDEDIR=0 -D LIBDIR=0 -D _POSIX_SOURCE -D HAVE_CONFIG_H -Wextensions -g  -Wnowarn=1506,161 -O2 $(INCLUDES) 
 GMAKE_EXE=gmake
 LDFLAGS=$(SYSTYPE_FLAG) -lrld
+
+.PHONY: version.o
 
 # List of object files
 objects = alloca.o  \
@@ -61,6 +65,10 @@ default : $(GMAKE_EXE)
 <cmd> $(CC) -c $(CFLAGS) -o $@ $<
 glob/%.o: glob/%.c
 <cmd> $(CC) -c $(CFLAGS) -o $@ $<
+
+version.o: version.c
+<cmd> $(CC) -c $(CFLAGS) -DVPROC=$(VPROC) -o $@ $<
+
 
 # Dependency details
 alloca.o       : config.h

--- a/ver.c
+++ b/ver.c
@@ -3,10 +3,6 @@
 #pragma section VERSION_STRING
 #define VERSION_STRING "T0593H01 - (01FEB2015)" __DATE__ __TIME__
 
-#pragma section VERSION_GMAKE
-void T0593H01_01FEB15_GMAKE_19SEP14(void)
-{}
-
 #pragma section CHANGES
 /* Begin change descriptons
 -----------------------------------------------------------------------------

--- a/version.c
+++ b/version.c
@@ -36,7 +36,8 @@ const char *make_host = MAKE_HOST;
 #define VERSION_STRING "T0593H01 - (30SEP2020)" __DATE__ __TIME__
 
 #pragma section VERSION_GMAKE
-void T0593H01_30SEP20_GMAKE_30SEP20_AAD_4_1(void)
+/* The VPROC variable needs to be defined on the command line. */
+void VPROC (void)
 {}
 
 #pragma section CHANGES

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+PRODUCT_NUMBER=T0593V01
+PRODUCT_NAME=GMAKE
+COMMITTER_DATE=`date --date="@\`git show -s --format=%ct HEAD\`" +%d%b%g | tr '[:lower:]' '[:upper:]'`
+VERSION_STRING=`git describe --tags --long | sed 's/-.*-/_/' | sed 's/\./_/g'`
+
+echo ${PRODUCT_NUMBER}_${COMMITTER_DATE}_${PRODUCT_NAME}_${VERSION_STRING}


### PR DESCRIPTION
This change also removes VPROC from ver.c, which was duplicated. VPROC is now
supplied as a -DVPROC argument to the version.c compile, which always happens
regardless of the timestamps.

CLA Permission is granted by the author to the ITUGLIB team to use these modifications.
Fixes #8.

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>