### PR TITLE
Add case-insensitive compare for archive member names.

### DIFF
--- a/arscan.c
+++ b/arscan.c
@@ -847,7 +847,11 @@ ar_name_equal (const char *name, const char *mem, int truncated)
 #endif /* !AIAMAG */
     }
 
+# ifdef _GUARDIAN_TARGET
+  return !strcasecmp (name, mem);
+# else
   return !strcmp (name, mem);
+# endif
 #else
   /* VMS members do not have suffixes, but the filenames usually
      have.


### PR DESCRIPTION
Partial fix #40

CLA: Trivial

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>