### PR TITLE
Add support for predefined GUARDIAN variables

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -10,7 +10,7 @@ of each out of date component. This port runs in the GUARDIAN personality of
 the NonStop J-series and L-series platforms and is subject to the capabilities
 available on those platforms.
 
-This edition, last updated on 24 February 2021, was written for the 4.1g5
+This edition, last updated on 06 August 2021, was written for the 4.1g5
 version of GMake, based on GNU Make 4.1. There have been many contributors to
 GMake including Hewlett-Packard Enterprise LLC, ITUGLIB Engineering Team - part
 of Connect Inc., and Nexbridge Inc.
@@ -117,6 +117,48 @@ The following predefined variables are added to GMake:
 | `SYSVOL` | `$SYSTEM.SYSTEM` | The default location of system programs.                   |
 | `OSHARGS`| `-osstty`         | Default arguments for OSH, specified in the $(SH) variable.|
 | `SH`      | `$(SYSVOL).OSH`  | The default location of OSH.                               |
+| `ARFLAGS`  | `rv`                  | AR program standard arguments.                            |
+| `AR`        | `$(SYSVOL).AR`      | Object Archive program location.                           |
+| `AXCEL`     | `$(SYSVOL).AXCEL`  | Non-Native Object Acceleration program location.           |
+| `BIND`     | `$(SYSVOL).BIND`     | BINDER program object location.                           |
+| `CC`        | `$(SYSVOL).C`        | C compiler program location.                              |
+| `COBEX`    | `$(SYSVOL).XCOBEX0`   | COBEX program location. `XCOBEX0` on J-series.         |
+| `COBOL`    | `$(SYSVOL).XCOBOL`    | Native COBOL program location. `ECOBOL` on J-series.    |
+| `COBOL85`  | `$(SYSVOL).COBOL85` | COBOL85 compiler program location.                        |
+| `CCOMP`    | `$(SYSVOL).CCOMP`    | CCOMP compiler program location.                          |
+| `CFRONT`   | `$(SYSVOL).CFRONT`   | CFRONT preprocessor program location.                     |
+| `CPP`       | `$(SYSVOL).C`        | C++ compiler program location.                            |
+| `CPPCOMP`  | `$(SYSVOL).CPPCOMP`  | C++ compiler  program location.                          |
+| `CTOEDIT`  | `$(SYSVOL).CTOEDIT`  | C-to-Edit conversion program location.                    |
+| `DDL`       | `$(SYSVOL).DDL`      | DDL compiler program location.                            |
+| `ENABLE`   | `$(SYSVOL).ENABLE`   | ENABLE  program location.                                 |
+| `EDIT`     | `$(SYSVOL).EDIT`      | EDIT utility program location.                           |
+| `EDITTOC`  | `$(SYSVOL).EDITTOC`  | Edit-to-C conversion program location.                    |
+| `FORTRAN`  | `$(SYSVOL).FORTRAN`  | FORTRAN compiler program location.                        |
+| `FUP`      | `$(SYSVOL).FUP`       | FUP utility program location.                             |
+| `LD`       | `$(SYSVOL).XLD`        | Linker program location. `ELD` on J-series.             |
+| `NMC`       | `$(SYSVOL).NMC`      | NMC compiler program location.                            |
+| `OCA`      | `$(SYSVOL).OCA`       | OCA program location.                                     |
+| `OSH`       | `$(SYSVOL).OSH $(OSHARGS)` | The default location of OSH and arguments.        |
+| `PATHCOM`  | `$(SYSVOL).PATHCOM`   | PATHCOM program location.                                |
+| `PDMCOM`   | `$(SYSVOL).PDMCOM`    | PDMCOM program location.                                 |
+| `PTAL`     | `$(SYSVOL).XPTAL`     | PTAL program location. `EPTAL` on J-series              |
+| `SCOBOL`   | `$(SYSVOL).SCOBOLX`  | SCOBOL compiler program location.                         |
+| `SCOBOLX`  | `$(SYSVOL).SCOBOLX`  | Alternate SCOBOL compiler program location.               |
+| `SCUP`     | `$(SYSVOL).SCUP`      | SCUP utility program location.                           |
+| `TACL`     | `$(SYSVOL).TACL`      | TACL interpreter program location.                        |
+| `TAL`       | `$(SYSVOL).TAL`      | TAL compiler program location.                            |
+| `TEMPL`    | `$(SYSVOL).TEMPL`     | TEMPL compiler program location.                          |
+| `TEMPLI`   | `$(SYSVOL).TEMPLI`    | Template installer program location.                     |
+| `TFORM`    | `$(SYSVOL).TFORM`     | TFORM documenter program location.                        |
+| `TGAL`     | `$(SYSVOL).TGAL`      | TGAL documenter program location.                         |
+| `SQLCI`    | `$(SYSVOL).SQLCI`     | SQLCI interpreter program location.                       |
+| `SQLCOMP`  | `$(SYSVOL).SQLCOMP`  | SQLCOMP compiler program location.                        |
+| `SPOOLCOM` | `$(SYSVOL).SPOOLCOM` | SPOOLCOM program location.                                |
+| `VPROC`    | `$(SYSVOL).VPROC`     | VPROC utility program location.                           |
+| `NSGITVOL` | `$SYSTEM.NSGIT`       | Default NSGit installation subvolume                     |
+| `GMAKEDEP` | `$(NSGITVOL).GMAKEDEP` | GMAKEDEP dependency generator program location.         |
+| `NSGIT`    | `$(NSGITVOL).NSGIT`   | NSGit program location.                                  |
 
 More variables will be defined in future releases.
 

--- a/default.c
+++ b/default.c
@@ -434,9 +434,11 @@ static const char *default_variables[] =
 
 #else /* !VMS */
 
+#ifndef _GUARDIAN_TARGET
     "AR", "ar",
     "ARFLAGS", "rv",
     "AS", "as",
+#endif
 #ifdef GCC_IS_NATIVE
     "CC", "gcc",
 # ifdef __MSDOS__
@@ -445,6 +447,60 @@ static const char *default_variables[] =
     "CXX", "gcc",
 # endif /* __MSDOS__ */
     "OBJC", "gcc",
+#elif defined(_GUARDIAN_TARGET)
+	"SYSVOL", "$SYSTEM.SYSTEM",
+	"NSGITVOL", "$SYSTEM.NSGIT",
+    "AR", "$(SYSVOL).AR",
+    "ARFLAGS", "rv",
+	"CC", "$(SYSVOL).C",
+	"CPP", "$(SYSVOL).C",
+	"NMC", "$(SYSVOL).NMC",
+	"TAL", "$(SYSVOL).TAL",
+	"OSHARGS", "-osstty",
+	"SH", "$(SYSVOL).OSH $(OSHARGS)",
+	"OSH", "$(SYSVOL).OSH $(OSHARGS)",
+	"COBOL85", "$(SYSVOL).COBOL85",
+	"CCOMP", "$(SYSVOL).CCOMP",
+	"CPPCOMP", "$(SYSVOL).CPPCOMP",
+	"CFRONT", "$(SYSVOL).CFRONT",
+	"SCOBOL", "$(SYSVOL).SCOBOLX",
+	"SCOBOLX", "$(SYSVOL).SCOBOLX",
+	"ENABLE", "$(SYSVOL).ENABLE",
+	"FUP", "$(SYSVOL).FUP",
+	"OCA", "$(SYSVOL).OCA",
+	"BIND", "$(SYSVOL).BIND",
+	"SQLCI", "$(SYSVOL).SQLCI",
+	"SQLCOMP", "$(SYSVOL).SQLCOMP",
+	"SPOOLCOM", "$(SYSVOL).SPOOLCOM",
+	"GMAKEDEP", "$(NSGITVOL).GMAKEDEP",
+	"TACL", "$(SYSVOL).TACL",
+	"DDL", "$(SYSVOL).DDL",
+	"AXCEL", "$(SYSVOL).AXCEL",
+	"CTOEDIT", "$(SYSVOL).CTOEDIT",
+	"EDITTOC", "$(SYSVOL).EDITTOC",
+	"FORTRAN", "$(SYSVOL).FORTRAN",
+	"PATHCOM", "$(SYSVOL).PATHCOM",
+	"PDMCOM", "$(SYSVOL).PDMCOM",
+	"SCUP", "$(SYSVOL).SCUP",
+	"TEMPL", "$(SYSVOL).TEMPL",
+	"TEMPLI", "$(SYSVOL).TEMPLI",
+	"EDIT", "$(SYSVOL).EDIT",
+	"TFORM", "$(SYSVOL).TFORM",
+	"TGAL", "$(SYSVOL).TGAL",
+	"VPROC", "$(SYSVOL).VPROC",
+#if defined (_TNS_E_TARGET)
+	"COBOL", "$(SYSVOL).ECOBOL",
+	"COBEX", "$(SYSVOL).ECOBEX0",
+	"PTAL", "$(SYSVOL).EPTAL",
+	"LD", "$(SYSVOL).ELD",
+#elif defined (_TNS_X_TARGET)
+	"COBOL", "$(SYSVOL).XCOBOL",
+	"COBEX", "$(SYSVOL).XCOBEX0",
+	"PTAL", "$(SYSVOL).XPTAL",
+	"LD", "$(SYSVOL).XLD",
+#endif
+	"NSGIT", "$(NSGITVOL).NSGIT",
+
 #else
     "CC", "cc",
     "CXX", "g++",
@@ -572,12 +628,6 @@ static const char *default_variables[] =
 #endif /* !VMS */
     /* Make this assignment to avoid undefined variable warnings.  */
     "GNUMAKEFLAGS", "",
-
-#if defined (_GUARDIAN_TARGET)
-	"SYSVOL", "$SYSTEM.SYSTEM",
-	"OSHARGS", "-osstty",
-	"SH", "$(SYSVOL).OSH $(OSHARGS)",
-#endif
     0, 0
   };
 


### PR DESCRIPTION
Fixes: #68

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/ituglib/gmake/CONTRIBUTING.md

Contributor License Agreements: if this is a significant change, make sure you have a line like the following (without quotes):

`CLA: Permission is granted by the author to the ITUGLIB team to use these modifications.`

You must have already signed a Contributor License Agreement and sent it to the ITUGLIB organizational contact.

If the contribution is trivial, place the following line in your comment:

`CLA: trivial`

Other than that, provide a description above this comment if there isn't one already about the purpose of the pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
