### PR TITLE
Define platform specific variables.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -10,8 +10,8 @@ of each out of date component. This port runs in the GUARDIAN personality of
 the NonStop J-series and L-series platforms and is subject to the capabilities
 available on those platforms.
 
-This edition, last updated on 06 August 2021, was written for the 4.1g5
-version of GMake, based on GNU Make 4.1. There have been many contributors to
+This edition, last updated on 20 August 2021, was written for the 4.1g5
+version of GMake, based on GNU Make 4.3. There have been many contributors to
 GMake including Hewlett-Packard Enterprise LLC, ITUGLIB Engineering Team - part
 of Connect Inc., and Nexbridge Inc.
 
@@ -117,6 +117,8 @@ The following predefined variables are added to GMake:
 
 | Variable  | Default            | Meaning                                                    |
 | --------- | ------------------ | -----------------------------------------------------------|
+| `TNS_PLATFORM` | `E`,`X`       | Operating system on which GMAKE is running.                |
+| `TOS_VERSION` | `J06`,`L21`, etc.       | Operating system release identifier.                   |
 | `SYSVOL` | `$SYSTEM.SYSTEM` | The default location of system programs.                   |
 | `OSHARGS`| `-osstty`         | Default arguments for OSH, specified in the $(SH) variable.|
 | `SH`      | `$(SYSVOL).OSH`  | The default location of OSH.                               |
@@ -140,7 +142,7 @@ The following predefined variables are added to GMake:
 | `FORTRAN`  | `$(SYSVOL).FORTRAN`  | FORTRAN compiler program location.                        |
 | `FUP`      | `$(SYSVOL).FUP`       | FUP utility program location.                             |
 | `LD`       | `$(SYSVOL).XLD`        | Linker program location. `ELD` on J-series.             |
-| `NMC`       | `$(SYSVOL).NMC`      | NMC compiler program location.                            |
+| `NMC`       | `$(SYSVOL).NMC`      | NMC compiler program location. J-series only.             |
 | `OCA`      | `$(SYSVOL).OCA`       | OCA program location.                                     |
 | `OSH`       | `$(SYSVOL).OSH $(OSHARGS)` | The default location of OSH and arguments.        |
 | `PATHCOM`  | `$(SYSVOL).PATHCOM`   | PATHCOM program location.                                |
@@ -167,7 +169,7 @@ More variables will be defined in future releases.
 
 ### Predefined Functions
 
-Some substitution functions are not supported by GMake or GMaken. Please check
+Some substitution functions are not supported by GMake. Please check
 individual functions before committing to their use.
 
 #### `$(add_define define-attributes)` (GMaken Only)
@@ -241,11 +243,6 @@ and setting `ASSIGNs` should be specified before running programs in a recipe.
             $(assign SSV0 $SYSTEM.SYSTEM)
             $(TAL) /in $</ $@
 
-__Note__: The `$(shell command)` function is planned for the 4.3 release of
-GMake.
-
-There are other functions that do not work in GMake.
-
 #### `$(delay time units)` (GMaken Only)
 
 The `$(delay time units)` function causes the current recipe to delay for
@@ -285,7 +282,7 @@ and setting `PARAMs` should be specified before running programs in a recipe.
             $(param SWAPVOL $SWAP)
             $(TAL) /in $</ $@
 
-#### `$(pname file)` ####
+#### `$(pname file)`
 
 The `pname` function converts a GUARDIAN file name into an OSS path. The
 GUARDIAN name can be fully or partially qualified and does not need to exist.
@@ -298,6 +295,20 @@ command `pname -s guardian-file`.
 
     SRC = $VOL.SUBVOL.FILE
     OSS_SRC = $(pname $(SRC))
+
+#### `$(shell command)` (GMaken Only)
+
+The shell command function is implemented in GMaken. This function executes the
+specified command in a TACL process, captures the output, and returns the
+result. Typically, the result should only be a single line of output. You can
+assign the result to a variable, for example:
+
+    VERSION:=$(shell nsgit describe --long --first-parent)
+
+captures the current version from the most recent git tag in the local NSGit
+repository. Caution must be used with the `$(shell)` function as not all
+programs are compatible with its use. Some OSH functions are known to cause
+problems for the `$(shell)` function and may not work as intended.
 
 ### Shell Control
 

--- a/config.h
+++ b/config.h
@@ -354,11 +354,17 @@
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "support@nexbridge.com"
 
+#if defined (_TNS_E_TARGET)
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "GNU make TNS/E"
-
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "GNU make 4.3g1 TNS/E"
+#define PACKAGE_STRING "GNU make 4.3g2 TNS/E"
+#elif defined (_TNS_X_TARGET)
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "GNU make TNS/X"
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "GNU make 4.3g2 TNS/X"
+#endif
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "make"
@@ -367,7 +373,7 @@
 #define PACKAGE_URL "http://www.gnu.org/software/make/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3g1"
+#define PACKAGE_VERSION "4.3g2"
 
 /* Define to the character that separates directories in PATH. */
 #define PATH_SEPARATOR_CHAR ':'
@@ -434,7 +440,7 @@
 
 
 /* Version number of package */
-#define VERSION "4.3g1"
+#define VERSION "4.3g2"
 
 /* Use platform specific coding */
 /* #undef WINDOWS32 */

--- a/default.c
+++ b/default.c
@@ -25,6 +25,11 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include "job.h"
 #include "commands.h"
 
+#if defined(__TANDEM)
+#include <sys/utsname.h>
+static char tos_version[8]; /* sizeof utsname.release */
+#endif
+
 /* Define GCC_IS_NATIVE if gcc is the native development environment on
    your system (gcc/bison/flex vs cc/yacc/lex).  */
 #if defined(__MSDOS__) || defined(__EMX__)
@@ -531,13 +536,21 @@ static const char *default_variables[] =
 # endif /* __MSDOS__ */
     "OBJC", "gcc",
 #elif defined(_GUARDIAN_TARGET)
+#if defined (_TNS_E_TARGET)
+	"TNS_PLATFORM", "E",
+#elif defined (_TNS_X_TARGET)
+	"TNS_PLATFORM", "X",
+#endif
+	"TOS_VERSION", tos_version,
 	"SYSVOL", "$SYSTEM.SYSTEM",
 	"NSGITVOL", "$SYSTEM.NSGIT",
     "AR", "$(SYSVOL).AR",
     "ARFLAGS", "rv",
 	"CC", "$(SYSVOL).C",
 	"CPP", "$(SYSVOL).C",
+#if defined (_TNS_E_TARGET)
 	"NMC", "$(SYSVOL).NMC",
+#endif
 	"TAL", "$(SYSVOL).TAL",
 	"OSHARGS", "-osstty",
 	"SH", "$(SYSVOL).OSH $(OSHARGS)",
@@ -793,6 +806,15 @@ install_default_implicit_rules (void)
     install_pattern_rule (p, 1);
 }
 
+#if defined(__TANDEM)
+static void set_tos_version(void) {
+  struct utsname name;
+  memset(&name, 0, sizeof(name));
+  uname(&name);
+  strcpy(tos_version, name.release);
+}
+#endif
+
 void
 define_default_variables (void)
 {
@@ -803,6 +825,10 @@ define_default_variables (void)
 
   for (s = default_variables; *s != 0; s += 2)
     define_variable (s[0], strlen (s[0]), s[1], o_default, 1);
+
+#if defined(__TANDEM)
+  set_tos_version();
+#endif
 }
 
 void


### PR DESCRIPTION
* Remove NMC from L-series builds.
* Add TNS_PLATFORM (E/X values only).
* Add TOS_VERSION support

Fixes: #74

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
