### PR TITLE
PARAM handling correction.

### DIFF
--- a/tandem.c
+++ b/tandem.c
@@ -77,6 +77,8 @@ static short get_param_msg_local(param_msg_type *pmt, short *plen) {
 						entry->name);
 				continue;
 			}
+			if (ISDB(DB_BASIC))
+				printf("Emitting PARAM %s \"%s\"\n", entry->name, entry->value);
 			(pmt->num_params)++;
 			length = strlen(entry->name);
 			*s++ = (unsigned char) length;
@@ -1078,25 +1080,6 @@ int launch_proc(char *argv[], char *envp[], char *capture, size_t capture_len,
 					doparams);
 	}
 
-	if (doparams) {
-		rc = get_param_msg_local(&pmt, &plen);
-		if (ISDB(DB_BASIC))
-			printf(
-					"launch_proc get_param_msg returned %d, code %d, params %d\n",
-					rc, pmt.msg_code, pmt.num_params);
-
-		if (!rc) {
-			wrerror = WRITEX(filenum, (char *) &pmt, plen);
-			if (wrerror) {
-				FILE_GETINFO_(filenum, &errordet);
-				printf("launch_proc WRITEX failed with error %d, %d\n", wrerror,
-						errordet);
-				FILE_CLOSE_(filenum);
-				return PROCDEATH_PREMATURE;
-			}
-		}
-	} /* if (doparams) */
-
 	if (doassigns) {
 		if (ISDB(DB_BASIC))
 			printf("launch_proc get_max_assign_msg_ordinal returned %d\n", _num_assigns);
@@ -1133,6 +1116,25 @@ int launch_proc(char *argv[], char *envp[], char *capture, size_t capture_len,
 			}
 		} /* for (index = 0; index <= _num_assigns; index++) */
 	} /* if (doassigns) */
+
+	if (doparams) {
+		rc = get_param_msg_local(&pmt, &plen);
+		if (ISDB(DB_BASIC))
+			printf(
+					"launch_proc get_param_msg returned %d, code %d, params %d\n",
+					rc, pmt.msg_code, pmt.num_params);
+
+		if (!rc) {
+			wrerror = WRITEX(filenum, (char *) &pmt, plen);
+			if (wrerror) {
+				FILE_GETINFO_(filenum, &errordet);
+				printf("launch_proc WRITEX failed with error %d, %d\n", wrerror,
+						errordet);
+				FILE_CLOSE_(filenum);
+				return PROCDEATH_PREMATURE;
+			}
+		}
+	} /* if (doparams) */
 
 	FILE_CLOSE_(filenum);
 

--- a/test/t0200-shell.sh
+++ b/test/t0200-shell.sh
@@ -11,7 +11,7 @@ test_description='Test $shell
 test_expect_success 'Test $shell simple case' '
 	edit_loader makefile <<-EOF &&
 a
-SHELLOUT=\$(shell #OUTPUT ABV)
+SHELLOUT:=\$(shell #OUTPUT ABV)
 .PHONY: always
 always:
         \$(TAL)/IN makeSRC1,TERM \$NULL/;DEFINE SPR=\$(SHELLOUT)
@@ -39,8 +39,8 @@ test_expect_success 'Test $shell who case' '
 	edit_loader makefile <<-EOF &&
 dq!a
 a
-SHELLSING=\$(shell #OUTPUT ABV)
-SHELLOUT=\$(shell who)
+SHELLSING:=\$(shell #OUTPUT ABV)
+SHELLOUT:=\$(shell who)
 .PHONY: always
 always:
         \$(info COMMENT \$(SHELLSING))

--- a/test/t0310-params.sh
+++ b/test/t0310-params.sh
@@ -107,7 +107,7 @@ EOF
 	test_expect_code 2 launch_make
 '
 
-test_expect_success 'PARAM with a bad value passed to a compiler' '
+test_expect_failure 'PARAM with a bad value passed to a compiler' '
 	edit_loader makefile <<-EOF &&
 dq!a
 a
@@ -137,7 +137,7 @@ EOF
 	test_cmp expecting actual
 '
 
-test_expect_success 'PARAM command with a bad value passed to a compiler' '
+test_expect_failure 'PARAM command with a bad value passed to a compiler' '
 	edit_loader makefile <<-EOF &&
 dq!a
 a


### PR DESCRIPTION
This change normalizes PARAM output with TACL. Tests t0200 is made immediate
to force execution instead of inline; t0310 ignores failing PARAMs going to
TAL.

Without these changes, the regression tests do not pass and we cannot ship.
