### PR TITLE
main.c: add break in decode_switches

### DIFF
--- a/main.c
+++ b/main.c
@@ -2917,6 +2917,7 @@ decode_switches (int argc, const char **argv, int env)
                 {
                 default:
                   abort ();
+                  break;
 
                 case ignore:
                   break;


### PR DESCRIPTION
Trivial removal of build warnings in c99. This should be a no-op.