### PR TITLE
Pass home term as a value to PROCESS_LAUNCH_ only if specified.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -10,12 +10,12 @@ of each out of date component. This port runs in the GUARDIAN personality of
 the NonStop J-series and L-series platforms and is subject to the capabilities
 available on those platforms.
 
-This edition, last updated on 21 April 2022, was written for the 4.3g6
+This edition, last updated on 27 January 2023, was written for the 4.3g7
 version of GMake, based on GNU Make 4.3. There have been many contributors to
 GMake including Hewlett-Packard Enterprise LLC, ITUGLIB Engineering Team - part
 of Connect Inc., and Nexbridge Inc.
 
-Copyright &copy; 2020-2022, ITUGLIB Engineering Team. Permission is granted to
+Copyright &copy; 2020-2023, ITUGLIB Engineering Team. Permission is granted to
 copy, distribute and/or modify this document under the terms of the GNU Free
 Documentation License, Version 1.3 or any later version published by the
 Free Software Foundation; with no Invariant Sections, with the Front-Cover

--- a/config.h
+++ b/config.h
@@ -358,12 +358,12 @@
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "GNU make TNS/E"
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "GNU make 4.3g6 TNS/E"
+#define PACKAGE_STRING "GNU make 4.3g7 TNS/E"
 #elif defined (_TNS_X_TARGET)
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "GNU make TNS/X"
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "GNU make 4.3g6 TNS/X"
+#define PACKAGE_STRING "GNU make 4.3g7 TNS/X"
 #endif
 
 /* Define to the one symbol short name of this package. */
@@ -373,7 +373,7 @@
 #define PACKAGE_URL "http://www.gnu.org/software/make/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3g6"
+#define PACKAGE_VERSION "4.3g7"
 
 /* Define to the character that separates directories in PATH. */
 #define PATH_SEPARATOR_CHAR ':'
@@ -440,7 +440,7 @@
 
 
 /* Version number of package */
-#define VERSION "4.3g6"
+#define VERSION "4.3g7"
 
 /* Use platform specific coding */
 /* #undef WINDOWS32 */

--- a/main.c
+++ b/main.c
@@ -2917,6 +2917,7 @@ decode_switches (int argc, const char **argv, int env)
                 {
                 default:
                   abort ();
+                  break;
 
                 case ignore:
                   break;

--- a/main.c
+++ b/main.c
@@ -2917,7 +2917,6 @@ decode_switches (int argc, const char **argv, int env)
                 {
                 default:
                   abort ();
-                  break;
 
                 case ignore:
                   break;

--- a/tandem.c
+++ b/tandem.c
@@ -504,6 +504,7 @@ int launch_proc(char *argv[], char *envp[], char *capture, size_t capture_len,
 	short anyfile = -1;
 	__int32_t len32 = 0;
 
+	strcpy(sethometerm, "");
 	snprintf(searchDefine, sizeof(searchDefine), "=%s", search_define);
 
 	if (strcasecmp(argv[0], "param") == 0) {
@@ -1029,8 +1030,11 @@ int launch_proc(char *argv[], char *envp[], char *capture, size_t capture_len,
 			ZSYS_VAL_PCREATOPT_DEFOVERRIDE;
 	plist.program_name = cmd;
 	plist.program_name_len = (long) strlen(cmd);
-	plist.hometerm_name = sethometerm;
-	plist.hometerm_name_len = (long) strlen(sethometerm);
+	// Set home term only if specified by the recipe command line
+	if (strlen(sethometerm) > 0) {
+		plist.hometerm_name = sethometerm;
+		plist.hometerm_name_len = (long) strlen(sethometerm);
+	}
 	error = PROCESS_LAUNCH_((void *) &plist, &errordet, (void *) &olist,
 			sizeof(olist), &olistlen);
 	if (error) {


### PR DESCRIPTION
The original code to support /TERM/ left the value in the sethometerm variable uninitialized, which worked sometimes, but values on the stack could corrupt the value of plist.hometerm_name.

Fixes: #98

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>
