### PR TITLE
Integrate time64 updates from GMAKE extensions into the base code.

### DIFF
--- a/Makefile.NSE.OSS
+++ b/Makefile.NSE.OSS
@@ -55,6 +55,7 @@ objects = alloca.o  \
           strcache.o \
           tandem.o \
           tandem_ext.o \
+          time64.o \
           variable.o \
           version.o \
           vpath.o \
@@ -103,6 +104,7 @@ signame.o      : config.h
 strcache.o     : makeint.h hash.h
 tandem.o       : makeint.h
 tandem_ext.o   : makeint.h
+time64.o       : time64.c time64.h
 variable.o     : makeint.h config.h dep.h filedef.h job.h commands.h variable.h
 version.o      : config.h
 vpath.o        : makeint.h config.h filedef.h variable.h

--- a/Makefile.NSE.Win
+++ b/Makefile.NSE.Win
@@ -54,6 +54,7 @@ objects = alloca.o  \
           strcache.o \
           tandem.o \
           tandem_ext.o \
+          time64.o \
           variable.o \
           version.o \
           vpath.o \
@@ -102,6 +103,7 @@ signame.o      : config.h
 strcache.o     : makeint.h hash.h
 tandem.o       : makeint.h
 tandem_ext.o   : makeint.h
+time64.o       : time64.c time64.h
 variable.o     : makeint.h config.h dep.h filedef.h job.h commands.h variable.h
 version.o      : config.h
 vpath.o        : makeint.h config.h filedef.h variable.h

--- a/Makefile.NSX.OSS
+++ b/Makefile.NSX.OSS
@@ -55,6 +55,7 @@ objects = alloca.o  \
           strcache.o \
           tandem.o \
           tandem_ext.o \
+          time64.o \
           variable.o \
           version.o \
           vpath.o \
@@ -103,6 +104,7 @@ signame.o      : config.h
 strcache.o     : makeint.h hash.h
 tandem.o       : makeint.h
 tandem_ext.o   : makeint.h
+time64.o       : time64.c time64.h
 variable.o     : makeint.h config.h dep.h filedef.h job.h commands.h variable.h
 version.o      : config.h
 vpath.o        : makeint.h config.h filedef.h variable.h

--- a/Makefile.NSX.Win
+++ b/Makefile.NSX.Win
@@ -54,6 +54,7 @@ objects = alloca.o  \
           strcache.o \
           tandem.o \
           tandem_ext.o \
+          time64.o \
           variable.o \
           version.o \
           vpath.o \
@@ -102,6 +103,7 @@ signame.o      : config.h
 strcache.o     : makeint.h hash.h
 tandem.o       : makeint.h
 tandem_ext.o   : makeint.h
+time64.o       : time64.c time64.h
 variable.o     : makeint.h config.h dep.h filedef.h job.h commands.h variable.h
 version.o      : config.h
 vpath.o        : makeint.h config.h filedef.h variable.h

--- a/ar.c
+++ b/ar.c
@@ -93,12 +93,12 @@ ar_member_date_1 (int desc UNUSED, const char *mem, int truncated,
 
 /* Return the modtime of NAME.  */
 
-time_t
+time64_t
 ar_member_date (const char *name)
 {
   char *arname;
   char *memname;
-  long int val;
+  int64_t val;
 
   ar_parse_name (name, &arname, &memname);
 
@@ -123,19 +123,31 @@ ar_member_date (const char *name)
   open_pobj_dll();
   open_copylib_dll();
   open_ddldict_dll();
-  if (IS_POBJ_ENABLED && is_pobj_func(arname))
-	val = pobj_scan_func (arname, pobj_member_date_1_func, memname);
-  else if (IS_COPYLIB_ENABLED && is_copylib_func(arname))
-	val = copylib_scan_func (arname, copylib_member_date_1_func, memname);
-  else if (IS_DDLDICT_ENABLED && is_ddldict_func(arname))
-	val = ddldict_scan_func (arname, ddldict_member_date_1_func, memname);
-  else
+  if (IS_POBJ_ENABLED && is_pobj_func(arname)) {
+    if (pobj_member_date_64_func) {
+	  val = pobj_scan_64_func (arname, pobj_member_date_64_func, memname);
+    } else {
+  	  val = pobj_scan_func (arname, pobj_member_date_1_func, memname);
+    }
+  } else if (IS_COPYLIB_ENABLED && is_copylib_func(arname)) {
+    if (copylib_scan_64_func) {
+	  val = copylib_scan_64_func (arname, copylib_member_date_64_func, memname);
+    } else {
+  	  val = copylib_scan_func (arname, copylib_member_date_1_func, memname);
+    }
+  } else if (IS_DDLDICT_ENABLED && is_ddldict_func(arname)) {
+    if (ddldict_scan_64_func) {
+      val = ddldict_scan_64_func (arname, ddldict_member_date_64_func, memname);
+    } else {
+      val = ddldict_scan_func (arname, ddldict_member_date_1_func, memname);
+    }
+  } else
 #endif
   val = ar_scan (arname, ar_member_date_1, memname);
 
   free (arname);
 
-  return (val <= 0 ? (time_t) -1 : (time_t) val);
+  return (val <= 0 ? (time64_t) -1 : (time64_t) val);
 }
 
 /* Set the archive-member NAME's modtime to now.  */

--- a/arscan.c
+++ b/arscan.c
@@ -149,7 +149,7 @@ VMS_get_member_info(struct dsc$descriptor_s *module, unsigned long *rfa)
      VMS defectlet - mhddef is sub-optimal, for the time, it has a 32 bit
      longword, mhd$l_datim, and a 32 bit fill instead of two longwords, or
      equivalent. */
-  member_date = vms_time_to_unix(&mhd->mhd$l_datim);
+  member_date = vms_o_unix(&mhd->mhd$l_datim);
   free(mhd);
 
   /* Here we have a problem.  The module name on VMS does not have

--- a/commands.c
+++ b/commands.c
@@ -632,9 +632,9 @@ delete_target (struct file *file, const char *on_behalf_of)
 #ifndef NO_ARCHIVES
   if (ar_name (file->name))
     {
-      time_t file_date = (file->last_mtime == NONEXISTENT_MTIME
-                          ? (time_t) -1
-                          : (time_t) FILE_TIMESTAMP_S (file->last_mtime));
+      time64_t file_date = (file->last_mtime == NONEXISTENT_MTIME
+                          ? (time64_t) -1
+                          : (time64_t) FILE_TIMESTAMP_S (file->last_mtime));
       if (ar_member_date (file->name) != file_date)
         {
           if (on_behalf_of)

--- a/copylib.h
+++ b/copylib.h
@@ -1,16 +1,20 @@
 #pragma once
 
+#include <stdint.h>
+
 /*
  * TANDEM COPYLIB support extensions. This DLL module is designed as a plugin for
  * GMAKE managed by ITUGLIB. The contents of the COPYLIB DLL are under commercial
  * license.
  * @author Randall S. Becker
- * @copyright Copyright (c) 2021 Nexbridge Inc. All rights reserved. Proprietary and
+ * @copyright Copyright (c) 2021,2025 Nexbridge Inc. All rights reserved. Proprietary and
  * confidential except as specified in the GMake License terms. This header file
  * is contributed to the GMake GNUMake fork. The implementation is proprietary
  * and distinct from the GMake and GNUMake code base.
  */
 typedef long int (*copylib_member_func_t)(const void *entry,
+		const void *arg);
+typedef int64_t (*copylib_member_func_64_t)(const void *entry,
 		const void *arg);
 
 /* DLL Symbols - Do not modify this section. */
@@ -24,12 +28,16 @@ typedef void (*copylib_set_cache_add_function)(const char *(*fcn)(const char *))
 #define COPYLIB_SET_CACHE_ADD "copylib_set_cache_add"
 typedef long int (*copylib_member_date_1_function)(const void *entry, const void *name);
 #define COPYLIB_MEMBER_DATE_1 "copylib_member_date_1"
+typedef int64_t (*copylib_member_date_64_function)(const void *entry, const void *name);
+#define COPYLIB_MEMBER_DATE_64 "copylib_member_date_64"
 typedef long int (*copylib_glob_match_function)(const void *entry, const void *arg);
 #define COPYLIB_GLOB_MATCH "copylib_glob_match"
 typedef int (*is_copylib_function)(const char *copylibdir);
 #define IS_COPYLIB "is_copylib"
 typedef long int (*copylib_scan_function)(const char *copylibdir, copylib_member_func_t function, const void *arg);
 #define COPYLIB_SCAN "copylib_scan"
+typedef int64_t (*copylib_scan_64_function)(const char *copylibdir, copylib_member_func_64_t function, const void *arg);
+#define COPYLIB_SCAN_64 "copylib_scan_64"
 typedef int (*copylib_member_touch_function)(const char *copylibdir, const char *reqname);
 #define COPYLIB_MEMBER_TOUCH "copylib_member_touch"
 typedef int (*copylib_report_version_function)(const char *precede);
@@ -48,9 +56,11 @@ extern copylib_set_debug_level_function copylib_set_debug_level_func;
 extern copylib_reindex_function copylib_reindex_func;
 extern copylib_set_cache_add_function copylib_set_cache_add_func;
 extern copylib_member_date_1_function copylib_member_date_1_func;
+extern copylib_member_date_64_function copylib_member_date_64_func;
 extern copylib_glob_match_function copylib_glob_match_func;
 extern is_copylib_function is_copylib_func;
 extern copylib_scan_function copylib_scan_func;
+extern copylib_scan_64_function copylib_scan_64_func;
 extern copylib_member_touch_function copylib_member_touch_func;
 extern copylib_report_version_function copylib_report_version_func;
 extern void close_copylib_dll(void);
@@ -63,9 +73,11 @@ copylib_set_debug_level_function copylib_set_debug_level_func;
 copylib_reindex_function copylib_reindex_func;
 copylib_set_cache_add_function copylib_set_cache_add_func;
 copylib_member_date_1_function copylib_member_date_1_func;
+copylib_member_date_64_function copylib_member_date_64_func;
 copylib_glob_match_function copylib_glob_match_func;
 is_copylib_function is_copylib_func;
 copylib_scan_function copylib_scan_func;
+copylib_scan_64_function copylib_scan_64_func;
 copylib_member_touch_function copylib_member_touch_func;
 copylib_report_version_function copylib_report_version_func;
 
@@ -82,9 +94,11 @@ void close_copylib_dll(void)
       copylib_reindex_func = NULL;
       copylib_set_cache_add_func = NULL;
       copylib_member_date_1_func = NULL;
+      copylib_member_date_64_func = NULL;
       copylib_glob_match_func = NULL;
       is_copylib_func = NULL;
       copylib_scan_func = NULL;
+      copylib_scan_64_func = NULL;
       copylib_member_touch_func = NULL;
       copylib_report_version_func = NULL;
       copylibChecked = 0;
@@ -116,12 +130,16 @@ void open_copylib_dll(void)
             (copylib_set_cache_add_function) dlsym(handleCopylib, COPYLIB_SET_CACHE_ADD);
           copylib_member_date_1_func =
             (copylib_member_date_1_function) dlsym(handleCopylib, COPYLIB_MEMBER_DATE_1);
+          copylib_member_date_64_func =
+            (copylib_member_date_64_function) dlsym(handleCopylib, COPYLIB_MEMBER_DATE_64);
           copylib_glob_match_func =
             (copylib_glob_match_function) dlsym(handleCopylib, COPYLIB_GLOB_MATCH);
           is_copylib_func =
             (is_copylib_function) dlsym(handleCopylib, IS_COPYLIB);
           copylib_scan_func =
             (copylib_scan_function) dlsym(handleCopylib, COPYLIB_SCAN);
+          copylib_scan_64_func =
+            (copylib_scan_64_function) dlsym(handleCopylib, COPYLIB_SCAN_64);
           copylib_member_touch_func =
             (copylib_member_touch_function) dlsym(handleCopylib, COPYLIB_MEMBER_TOUCH);
           copylib_report_version_func =
@@ -189,6 +207,9 @@ void copylib_set_cache_add(const char *(*fcn)(const char *));
 long int
 copylib_member_date_1 (const void *entry, const void *name);
 
+int64_t
+copylib_member_date_64 (const void *entry, const void *name);
+
 long int
 copylib_glob_match (const void *entry, const void *arg);
 
@@ -198,6 +219,9 @@ is_copylib(const char *copylibdir);
 
 long int
 copylib_scan (const char *copylibdir, copylib_member_func_t function, const void *arg);
+
+long int
+copylib_scan_64 (const char *copylibdir, copylib_member_func_64_t function, const void *arg);
 
 int
 copylib_member_touch (const char *copylibdir, const char *reqname);

--- a/ddldict.h
+++ b/ddldict.h
@@ -1,16 +1,20 @@
 #pragma once
 
+#include <stdint.h>
+
 /*
  * TANDEM DDLDICT support extensions. This DLL module is designed as a plugin for
  * GMAKE managed by ITUGLIB. The contents of the DDLDICT DLL are under commercial
  * license.
  * @author Randall S. Becker
- * @copyright Copyright (c) 2021 Nexbridge Inc. All rights reserved. Proprietary and
+ * @copyright Copyright (c) 2021,2025 Nexbridge Inc. All rights reserved. Proprietary and
  * confidential except as specified in the GMake License terms. This header file
  * is contributed to the GMake GNUMake fork. The implementation is proprietary
  * and distinct from the GMake and GNUMake code base.
  */
 typedef long int (*ddldict_member_func_t)(const void *entry,
+		const void *arg);
+typedef int64_t (*ddldict_member_func_64_t)(const void *entry,
 		const void *arg);
 
 /* DLL Symbols - Do not modify this section. */
@@ -22,12 +26,16 @@ typedef void (*ddldict_set_cache_add_function)(const char *(*fcn)(const char *))
 #define DDLDICT_SET_CACHE_ADD "ddldict_set_cache_add"
 typedef long int (*ddldict_member_date_1_function)(const void *entry, const void *name);
 #define DDLDICT_MEMBER_DATE_1 "ddldict_member_date_1"
+typedef int64_t (*ddldict_member_date_64_function)(const void *entry, const void *name);
+#define DDLDICT_MEMBER_DATE_64 "ddldict_member_date_64"
 typedef long int (*ddldict_glob_match_function)(const void *entry, const void *arg);
 #define DDLDICT_GLOB_MATCH "ddldict_glob_match"
 typedef int (*is_ddldict_function)(const char *ddldictdir);
 #define IS_DDLDICT "is_ddldict"
 typedef long int (*ddldict_scan_function)(const char *ddldictdir, ddldict_member_func_t function, const void *arg);
 #define DDLDICT_SCAN "ddldict_scan"
+typedef int64_t (*ddldict_scan_64_function)(const char *ddldictdir, ddldict_member_func_64_t function, const void *arg);
+#define DDLDICT_SCAN_64 "ddldict_scan_64"
 typedef int (*ddldict_member_touch_function)(const char *ddldictdir, const char *reqname);
 #define DDLDICT_MEMBER_TOUCH "ddldict_member_touch"
 typedef int (*ddldict_report_version_function)(const char *precede);
@@ -45,9 +53,12 @@ extern int ddldictChecked;
 extern ddldict_set_debug_level_function ddldict_set_debug_level_func;
 extern ddldict_set_cache_add_function ddldict_set_cache_add_func;
 extern ddldict_member_date_1_function ddldict_member_date_1_func;
+extern ddldict_member_date_64_function ddldict_member_date_64_func;
+
 extern ddldict_glob_match_function ddldict_glob_match_func;
 extern is_ddldict_function is_ddldict_func;
 extern ddldict_scan_function ddldict_scan_func;
+extern ddldict_scan_64_function ddldict_scan_64_func;
 extern ddldict_member_touch_function ddldict_member_touch_func;
 extern ddldict_report_version_function ddldict_report_version_func;
 extern void close_ddldict_dll(void);
@@ -59,9 +70,11 @@ int ddldictChecked = 0;
 ddldict_set_debug_level_function ddldict_set_debug_level_func;
 ddldict_set_cache_add_function ddldict_set_cache_add_func;
 ddldict_member_date_1_function ddldict_member_date_1_func;
+ddldict_member_date_64_function ddldict_member_date_64_func;
 ddldict_glob_match_function ddldict_glob_match_func;
 is_ddldict_function is_ddldict_func;
 ddldict_scan_function ddldict_scan_func;
+ddldict_scan_64_function ddldict_scan_64_func;
 ddldict_member_touch_function ddldict_member_touch_func;
 ddldict_report_version_function ddldict_report_version_func;
 
@@ -77,9 +90,11 @@ void close_ddldict_dll(void)
       ddldict_set_debug_level_func = NULL;
       ddldict_set_cache_add_func = NULL;
       ddldict_member_date_1_func = NULL;
+      ddldict_member_date_64_func = NULL;
       ddldict_glob_match_func = NULL;
       is_ddldict_func = NULL;
       ddldict_scan_func = NULL;
+      ddldict_scan_64_func = NULL;
       ddldict_member_touch_func = NULL;
       ddldict_report_version_func = NULL;
       ddldictChecked = 0;
@@ -109,12 +124,16 @@ void open_ddldict_dll(void)
             (ddldict_set_cache_add_function) dlsym(handleDdlDict, DDLDICT_SET_CACHE_ADD);
           ddldict_member_date_1_func =
             (ddldict_member_date_1_function) dlsym(handleDdlDict, DDLDICT_MEMBER_DATE_1);
+          ddldict_member_date_64_func =
+            (ddldict_member_date_64_function) dlsym(handleDdlDict, DDLDICT_MEMBER_DATE_64);
           ddldict_glob_match_func =
             (ddldict_glob_match_function) dlsym(handleDdlDict, DDLDICT_GLOB_MATCH);
           is_ddldict_func =
             (is_ddldict_function) dlsym(handleDdlDict, IS_DDLDICT);
           ddldict_scan_func =
             (ddldict_scan_function) dlsym(handleDdlDict, DDLDICT_SCAN);
+          ddldict_scan_64_func =
+            (ddldict_scan_64_function) dlsym(handleDdlDict, DDLDICT_SCAN_64);
           ddldict_member_touch_func =
             (ddldict_member_touch_function) dlsym(handleDdlDict, DDLDICT_MEMBER_TOUCH);
           ddldict_report_version_func =
@@ -182,6 +201,9 @@ void ddldict_set_cache_add(const char *(*fcn)(const char *));
 long int
 ddldict_member_date_1 (const void *entry, const void *name);
 
+int64_t
+ddldict_member_date_64 (const void *entry, const void *name);
+
 long int
 ddldict_glob_match (const void *entry, const void *arg);
 
@@ -191,6 +213,9 @@ is_ddldict(const char *ddldictdir);
 
 long int
 ddldict_scan (const char *ddldictdir, ddldict_member_func_t function, const void *arg);
+
+int64_t
+ddldict_scan_64 (const char *ddldictdir, ddldict_member_func_64_t function, const void *arg);
 
 int
 ddldict_member_touch (const char *ddldictdir, const char *reqname);

--- a/dir.c
+++ b/dir.c
@@ -252,8 +252,8 @@ struct directory_contents
      * qualified name of the directory. Beware though, this is also
      * unreliable. I'm open to suggestion on a better way to emulate inode.  */
     char *path_key;
-    time_t ctime;
-    time_t mtime;        /* controls check for stale directory cache */
+    time64_t ctime;
+    time64_t mtime;        /* controls check for stale directory cache */
     int fs_flags;     /* FS_FAT, FS_NTFS, ... */
 # define FS_FAT      0x1
 # define FS_NTFS     0x2
@@ -664,7 +664,7 @@ dir_contents_file_exists_p (struct directory_contents *dir,
         {
           if ((dir->fs_flags & FS_FAT) != 0)
             {
-              dir->mtime = time ((time_t *) 0);
+              dir->mtime = time ((time64_t *) 0);
               rehash = 1;
             }
           else if (stat (dir->path_key, &st) == 0 && st.st_mtime > dir->mtime)
@@ -790,7 +790,7 @@ file_exists_p (const char *name)
 
 #ifndef NO_ARCHIVES
   if (ar_name (name))
-    return ar_member_date (name) != (time_t) -1;
+    return ar_member_date (name) != (time64_t) -1;
 #endif
 
 #ifdef _GUARDIAN_TARGET

--- a/filedef.h
+++ b/filedef.h
@@ -169,7 +169,7 @@ int stemlen_compare (const void *v1, const void *v2);
     * 302 / 1000) \
    + 1 + 1 + 4 + 25)
 
-FILE_TIMESTAMP file_timestamp_cons (char const *, time_t, long int);
+FILE_TIMESTAMP file_timestamp_cons (char const *, time64_t, long int);
 FILE_TIMESTAMP file_timestamp_now (int *);
 void file_timestamp_sprintf (char *p, FILE_TIMESTAMP ts);
 

--- a/job.c
+++ b/job.c
@@ -2049,7 +2049,7 @@ load_too_high (void)
   return 1;
 #else
   static double last_sec;
-  static time_t last_now;
+  static time64_t last_now;
 
   /* This is disabled by default for now, because it will behave badly if the
      user gives a value > the number of cores; in that situation the load will
@@ -2063,7 +2063,7 @@ load_too_high (void)
   static int proc_fd = PROC_FD_INIT;
 
   double load, guess;
-  time_t now;
+  time64_t now;
 
 #ifdef WINDOWS32
   /* sub_proc.c is limited in the number of objects it can wait for. */

--- a/main.c
+++ b/main.c
@@ -14,6 +14,7 @@ A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
+#include "time64.h"
 #include "makeint.h"
 #include "os.h"
 #include "filedef.h"
@@ -3453,11 +3454,11 @@ print_version (void)
 static void
 print_data_base (void)
 {
-  time_t when = time ((time_t *) 0);
+  time64_t when = time64_ext ((time64_t *) 0);
 
   print_version ();
 
-  printf (_("\n# Make data base, printed on %s"), ctime (&when));
+  printf (_("\n# Make data base, printed on %s"), ctime64_ext (&when));
 
   print_variable_data_base ();
   print_dir_data_base ();
@@ -3466,8 +3467,8 @@ print_data_base (void)
   print_vpath_data_base ();
   strcache_print_stats ("#");
 
-  when = time ((time_t *) 0);
-  printf (_("\n# Finished Make data base on %s\n"), ctime (&when));
+  when = time64_ext ((time64_t *) 0);
+  printf (_("\n# Finished Make data base on %s\n"), ctime64_ext (&when));
 }
 
 static void

--- a/makeint.h
+++ b/makeint.h
@@ -558,7 +558,7 @@ void *memrchr(const void *, int, size_t);
 int ar_name (const char *);
 void ar_parse_name (const char *, char **, char **);
 int ar_touch (const char *);
-time_t ar_member_date (const char *);
+time64_t ar_member_date (const char *);
 
 typedef long int (*ar_member_func_t) (int desc, const char *mem, int truncated,
                                       long int hdrpos, long int datapos,

--- a/pobj.h
+++ b/pobj.h
@@ -1,16 +1,20 @@
 #pragma once
 
+#include <stdint.h>
+
 /*
  * SCOBOL POBJ support extensions. This DLL module is designed as a plugin for
  * GMAKE managed by ITUGLIB. The contents of the POBJ DLL are under commercial
  * license.
  * @author Randall S. Becker
- * @copyright Copyright (c) 2021 Nexbridge Inc. All rights reserved. Proprietary and
+ * @copyright Copyright (c) 2021,2025 Nexbridge Inc. All rights reserved. Proprietary and
  * confidential except as specified in the GMake License terms. This header file
  * is contributed to the GMake GNUMake fork. The implementation is proprietary
  * and distinct from the GMake and GNUMake code base.
  */
 typedef long int (*pobj_member_func_t)(const void *desc, const void *entry,
+		const void *arg);
+typedef int64_t (*pobj_member_func_64_t)(const void *desc, const void *entry,
 		const void *arg);
 
 /* DLL Symbols - Do not modify this section. */
@@ -22,12 +26,16 @@ typedef void (*pobj_set_cache_add_function)(const char *(*fcn)(const char *));
 #define POBJ_SET_CACHE_ADD "pobj_set_cache_add"
 typedef long int (*pobj_member_date_1_function)(const void *desc, const void *entry, const void *name);
 #define POBJ_MEMBER_DATE_1 "pobj_member_date_1"
+typedef int64_t (*pobj_member_date_64_function)(const void *desc, const void *entry, const void *name);
+#define POBJ_MEMBER_DATE_64 "pobj_member_date_64"
 typedef long int (*pobj_glob_match_function)(const void *desc, const void *entry, const void *arg);
 #define POBJ_GLOB_MATCH "pobj_glob_match"
 typedef int (*is_pobj_function)(const char *pobjdir);
 #define IS_POBJ "is_pobj"
 typedef long int (*pobj_scan_function)(const char *pobjdir, pobj_member_func_t function, const void *arg);
 #define POBJ_SCAN "pobj_scan"
+typedef int64_t (*pobj_scan_64_function)(const char *pobjdir, pobj_member_func_64_t function, const void *arg);
+#define POBJ_SCAN_64 "pobj_scan_64"
 typedef int (*pobj_member_touch_function)(const char *pobjdir, const char *reqname);
 #define POBJ_MEMBER_TOUCH "pobj_member_touch"
 typedef int (*pobj_report_version_function)(const char *precede);
@@ -44,9 +52,11 @@ static int pobjChecked = 0;
 static pobj_set_debug_level_function pobj_set_debug_level_func;
 static pobj_set_cache_add_function pobj_set_cache_add_func;
 static pobj_member_date_1_function pobj_member_date_1_func;
+static pobj_member_date_64_function pobj_member_date_64_func;
 static pobj_glob_match_function pobj_glob_match_func;
 static is_pobj_function is_pobj_func;
 static pobj_scan_function pobj_scan_func;
+static pobj_scan_64_function pobj_scan_64_func;
 static pobj_member_touch_function pobj_member_touch_func;
 static pobj_report_version_function pobj_report_version_func;
 
@@ -62,9 +72,11 @@ static void close_pobj_dll(void)
       pobj_set_debug_level_func = NULL;
       pobj_set_cache_add_func = NULL;
       pobj_member_date_1_func = NULL;
+      pobj_member_date_64_func = NULL;
       pobj_glob_match_func = NULL;
       is_pobj_func = NULL;
       pobj_scan_func = NULL;
+      pobj_scan_64_func = NULL;
       pobj_member_touch_func = NULL;
       pobj_report_version_func = NULL;
       pobjChecked = 0;
@@ -94,12 +106,16 @@ static void open_pobj_dll(void)
             (pobj_set_cache_add_function) dlsym(handlePobj, POBJ_SET_CACHE_ADD);
           pobj_member_date_1_func =
             (pobj_member_date_1_function) dlsym(handlePobj, POBJ_MEMBER_DATE_1);
+          pobj_member_date_64_func =
+            (pobj_member_date_64_function) dlsym(handlePobj, POBJ_MEMBER_DATE_64);
           pobj_glob_match_func =
             (pobj_glob_match_function) dlsym(handlePobj, POBJ_GLOB_MATCH);
           is_pobj_func =
             (is_pobj_function) dlsym(handlePobj, IS_POBJ);
           pobj_scan_func =
             (pobj_scan_function) dlsym(handlePobj, POBJ_SCAN);
+          pobj_scan_64_func =
+            (pobj_scan_64_function) dlsym(handlePobj, POBJ_SCAN_64);
           pobj_member_touch_func =
             (pobj_member_touch_function) dlsym(handlePobj, POBJ_MEMBER_TOUCH);
           pobj_report_version_func =
@@ -166,6 +182,9 @@ void pobj_set_cache_add(const char *(*fcn)(const char *));
 long int
 pobj_member_date_1 (const void *desc, const void *entry, const void *name);
 
+int64_t
+pobj_member_date_64 (const void *desc, const void *entry, const void *name);
+
 long int
 pobj_glob_match (const void *desc, const void *entry, const void *arg);
 
@@ -175,6 +194,9 @@ is_pobj(const char *pobjdir);
 
 long int
 pobj_scan (const char *pobjdir, pobj_member_func_t function, const void *arg);
+
+int64_t
+pobj_scan_64 (const char *pobjdir, pobj_member_func_64_t function, const void *arg);
 
 int
 pobj_member_touch (const char *pobjdir, const char *reqname);

--- a/remake.c
+++ b/remake.c
@@ -1272,7 +1272,7 @@ f_mtime (struct file *file, int search)
 
       char *arname, *memname;
       struct file *arfile;
-      time_t member_date;
+      time64_t member_date;
 
       /* Find the archive's name.  */
       ar_parse_name (file->name, &arname, &memname);
@@ -1320,7 +1320,7 @@ f_mtime (struct file *file, int search)
         return NONEXISTENT_MTIME;
 
       member_date = ar_member_date (file->hname);
-      mtime = (member_date == (time_t) -1
+      mtime = (member_date == (time64_t) -1
                ? NONEXISTENT_MTIME
                : file_timestamp_cons (file->hname, member_date, 0));
     }

--- a/test/t9000-pobj-extensions.sh
+++ b/test/t9000-pobj-extensions.sh
@@ -70,7 +70,7 @@ EOF
 	launch_make > actual &&
 	launch_spoolcom_delete $this_test >/dev/null &&
 	cat >expecting <<-EOF &&
-	\$SYSTEM.SYSTEM.SCOBOLX/IN nsgreqs,OUT =SPOOL/pobj
+	\$SYSTEM.SYSTEM.SCOBOLX/IN nsgreqs,OUT =SPOOL,TERM \$NULL/pobj
 	EOF
 	test_cmp expecting actual
 '
@@ -83,6 +83,7 @@ test_expect_success POBJDLL 'retest compile - should not run' '
 '
 
 test_expect_success POBJDLL 'recompile - changed source' '
+	sleep 2 &&
 	edit_loader nsgreqs <<-EOF > /dev/null &&
 a
 
@@ -98,11 +99,13 @@ EOF
 '
 
 test_expect_success POBJDLL 'pobj member touch' '
+	sleep 2 &&
 	edit_loader nsgreqs <<-EOF > /dev/null &&
 a
 
 //
 EOF
+	sleep 2 &&
 	launch_make --touch > actual &&
 	cat >expecting <<-EOF &&
 	touch pobjdir(nsgreqs)
@@ -110,8 +113,10 @@ EOF
 	test_cmp expecting actual
 '
 
-test_expect_success POBJDLL 'retest compile after touch - should not run' '
+test_expect_failure POBJDLL 'retest compile after touch - should not run - issue #120' '
+	sleep 2 &&
 	launch_make > capture &&
+	cat capture &&
 	sed "1,\$s/^.*:/:/" < capture > actual &&
 	echo ": Nothing to be done for ${QUOTE}all${QUOTE}." >expecting &&
 	test_cmp expecting actual

--- a/test/t9100-copylib-extensions.sh
+++ b/test/t9100-copylib-extensions.sh
@@ -91,6 +91,7 @@ test_expect_success COPYDLL 'retest compile - should not run' '
 '
 
 test_expect_success COPYDLL 'recompile - changed copy2 section C' '
+	sleep 2 &&
 	edit_loader copy2 <<-EOF > /dev/null &&
 a
 

--- a/time64.c
+++ b/time64.c
@@ -1,0 +1,73 @@
+/**
+ * @file
+ * 64-bit time conversion for GMAKE extension libraries.
+ * @author Randall S. Becker
+ * @copyright Copyright (c) 2025 Nexbridge Inc. All rights reserved. Proprietary and
+ * confidential. Disclosure without written permission violates international
+ * laws and will be prosecuted.
+ */
+#include "time64.h" // Must be first.
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <cextdecs.h>
+#include <time.h>
+
+
+static unsigned long long time64_to_lct(unsigned long long julianGmt) {
+	return CONVERTTIMESTAMP(julianGmt, 0);
+}
+
+int64_t time64_ext(int64_t *now) {
+	int64_t unixNow = time64_from_julian(JULIANTIMESTAMP());
+
+	if (now) {
+		*now = unixNow;
+	}
+
+	return unixNow;
+}
+
+struct tm *localtime64_ext(const int64_t *current) {
+	unsigned long long tandemNowLct = time64_to_lct(time64_to_julian(*current));
+	short dateAndTime[8];
+	struct tm *tm = (struct tm *) calloc(1, sizeof(struct tm));
+
+	INTERPRETTIMESTAMP(tandemNowLct, dateAndTime);
+	tm->tm_year = dateAndTime[0] - 1900;
+	tm->tm_mon = dateAndTime[1] - 1;
+	tm->tm_mday = dateAndTime[2];
+	tm->tm_hour = dateAndTime[3];
+	tm->tm_min = dateAndTime[4];
+	tm->tm_sec = dateAndTime[5];
+
+	return tm;
+}
+
+char *ctime64_ext(const int64_t *current) {
+	static char buffer[256];
+	struct tm *tm = localtime64_ext(current);
+	char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", //
+			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+	};
+
+	snprintf(buffer, sizeof(buffer), "%04d %s %d %02d:%02d:%02d\n",
+			tm->tm_year, tm->tm_mon, tm->tm_mday, //
+			tm->tm_hour, tm->tm_min, tm->tm_sec);
+	return buffer;
+}
+
+int64_t time64_from_julian(const unsigned long long julian) {
+	int64_t unixTime = (julian/1000000LL) - CONVERT_JULIAN_TO_UNIX;
+
+	return unixTime;
+}
+
+unsigned long long time64_to_julian(const int64_t unixTime) {
+	unsigned long long julian = (unixTime + CONVERT_JULIAN_TO_UNIX) * 1000000LL;
+
+	return julian;
+}
+

--- a/time64.h
+++ b/time64.h
@@ -1,0 +1,89 @@
+#ifndef _EXT_TIME64_H_
+#define _EXT_TIME64_H_
+/**
+ * @file
+ * 64-bit time conversion for GMAKE extension libraries.
+ * @author Randall S. Becker
+ * @copyright Copyright (c) 2025 Nexbridge Inc. All rights reserved. Proprietary and
+ * confidential. Disclosure without written permission violates international
+ * laws and will be prosecuted.
+ */
+
+#define _LARGEFILE64_SOURCE 1
+#define _XOPEN_SOURCE
+#define _XOPEN_SOURCE_EXTENDED 1
+
+#include <sys/types.h>
+#include <stdint.h>
+
+/**
+ * Conversion between Julian seconds to Unix seconds, through 3000+
+ */
+#define CONVERT_JULIAN_TO_UNIX 210866760000LL
+
+/** Conversion between old and new times. */
+#define CONVERT_48_BIT_OFFSET 211024440000000000LL
+
+/**
+ * A timestamp is a six byte binary value which indicates the number of
+ * hundredths of a second since midnight, January 1, 1975.  The current time
+ * is returned, as a timestamp, by the Guardian TIMESTAMP procedure.  Dates
+ * and times should be stored in the database using timestamps.
+ */
+typedef char                            internal_timestamp_def[6];
+
+#pragma fieldalign platform stat64_post2038
+/**
+ * Structure for the post 2038 stat, compatible with
+ */
+struct  stat64_post2038 {
+        dev_t   st_dev;
+        ino_t   st_ino;
+        mode_t  st_mode;
+        nlink_t st_nlink;
+        unsigned int st_acl:1;
+        unsigned int __filler_1:7;
+        unsigned int st_fileprivs:8;   /* File privileges */
+        uid_t   st_uid;
+        gid_t   st_gid;
+        dev_t   st_rdev;
+        off64_t   st_size;
+        int64_t st_atime;
+        int64_t st_mtime;
+        int64_t st_ctime;
+        mode_t  st_basemode; /* ACL:  owning user and other permissions */
+        int     st_reserved4;
+        int64_t st_reserved8[3];
+}; /* struct stat */
+int    stat64_post2038_fcn(const char *, struct stat64_post2038 *);
+
+#pragma function stat64_post2038_fcn     (alias("statLP64_"), unspecified)
+
+/**
+ * Get a 64-bit time from a 32-bit application.
+ *
+ * @param now the variable into which to place the time. If this variable is
+ *     NULL, the time is returned but not set in this argument.
+ * @return the time value.
+ */
+int64_t time64_ext(int64_t *now);
+
+struct tm *localtime64_ext(const int64_t *current);
+
+char *ctime64_ext(const int64_t *current);
+
+/**
+ * Convert a julian timestamp to a UNIX 64-bit timestamp.
+ * @param julian the 64-bit julian timestamp in microseconds.
+ * @return the converted 64-bit UNIX time.
+ */
+int64_t time64_from_julian(const unsigned long long julian);
+
+/**
+ * Convert a UNIX 64-bit timestamp to a julian timestamp.
+ * @param unixTime the UNIX time. This can be any epoch within a NonStop value range.
+ * @return the converted julian timestamp.
+ */
+unsigned long long time64_to_julian(const int64_t unixTime);
+
+#endif /* _EXT_TIME64_H_ */


### PR DESCRIPTION
Includes Add sleep to allow timestamp differences on fast systems in various tests.

Fixes: #96
Fixes: 10-250131-4298 (Genesis)

`CLA: permission for these changes granted by Nexbridge Inc., per: Randall S. Becker.