### PR TITLE
Convert struct stat to stat64_post2038 where mtime is used.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -10,12 +10,12 @@ of each out of date component. This port runs in the Guardian personality of
 the NonStop J-series and L-series platforms and is subject to the capabilities
 available on those platforms.
 
-This edition, last updated on 17 October 2024, was written for the 4.3g9
+This edition, last updated on 21 February 2025, was written for the 4.3g10
 version of GMake, based on GNU Make 4.3. There have been many contributors to
 GMake including Hewlett-Packard Enterprise LLC, ITUGLIB Engineering Team - part
 of Connect Inc., and Nexbridge Inc.
 
-Copyright &copy; 2020-2024, ITUGLIB Engineering Team. Permission is granted to
+Copyright &copy; 2020-2025, ITUGLIB Engineering Team. Permission is granted to
 copy, distribute and/or modify this document under the terms of the GNU Free
 Documentation License, Version 1.3 or any later version published by the
 Free Software Foundation; with no Invariant Sections, with the Front-Cover

--- a/ar.c
+++ b/ar.c
@@ -33,6 +33,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 # include "copylib.h"
 # define DDLDICT_SUPPRESS_EXTERNALIZATION_VERSION
 # include "ddldict.h"
+# include "time64.h"
 #endif
 
 /* Return nonzero if NAME is an archive-member reference, zero if not.  An
@@ -197,7 +198,7 @@ ar_touch (const char *name)
         TOUCH_ERROR ("touch: open: ");
       else
         {
-          struct stat statbuf;
+          struct stat statbuf; // acceptable non-y2038 use
           char buf = 'x';
           int e;
 

--- a/commands.c
+++ b/commands.c
@@ -27,6 +27,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #ifdef _GUARDIAN_TARGET
 #include <cextdecs.h>
+#include "time64.h"
 #endif
 
 #if VMS
@@ -623,7 +624,11 @@ fatal_error_signal (int sig)
 static void
 delete_target (struct file *file, const char *on_behalf_of)
 {
+#if !defined _GUARDIAN_TARGET
   struct stat st;
+#else
+  struct stat64_post2038 st;
+#endif
   int e;
 
   if (file->precious || file->phony)
@@ -650,7 +655,7 @@ delete_target (struct file *file, const char *on_behalf_of)
     }
 #endif
 
-  EINTRLOOP (e, stat (file->name, &st));
+  EINTRLOOP (e, stat (file->name, (struct stat *)&st));
   if (e == 0
       && S_ISREG (st.st_mode)
       && FILE_TIMESTAMP_STAT_MODTIME (file->name, st) != file->last_mtime)

--- a/config.h
+++ b/config.h
@@ -352,18 +352,18 @@
 #define PACKAGE "make"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "support@nexbridge.com"
+#define PACKAGE_BUGREPORT "nonstopsupport@hpe.com"
 
 #if defined (_TNS_E_TARGET)
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "GNU make TNS/E"
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "GNU make 4.3g9 TNS/E"
+#define PACKAGE_STRING "GNU make 4.3g10 TNS/E"
 #elif defined (_TNS_X_TARGET)
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "GNU make TNS/X"
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "GNU make 4.3g9 TNS/X"
+#define PACKAGE_STRING "GNU make 4.3g10 TNS/X"
 #endif
 
 /* Define to the one symbol short name of this package. */
@@ -373,7 +373,7 @@
 #define PACKAGE_URL "http://www.gnu.org/software/make/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3g9"
+#define PACKAGE_VERSION "4.3g10"
 
 /* Define to the character that separates directories in PATH. */
 #define PATH_SEPARATOR_CHAR ':'
@@ -440,7 +440,7 @@
 
 
 /* Version number of package */
-#define VERSION "4.3g9"
+#define VERSION "4.3g10"
 
 /* Use platform specific coding */
 /* #undef WINDOWS32 */

--- a/dir.c
+++ b/dir.c
@@ -45,6 +45,7 @@ const char *vmsify (const char *name, int type);
 
 #ifdef _GUARDIAN_TARGET
 # include <cextdecs.h>
+# include "time64.h"
 #endif
 
 /* In GNU systems, <dirent.h> defines this macro for us.  */
@@ -462,7 +463,11 @@ find_directory (const char *name)
     {
       /* The directory was not found.  Create a new entry for it.  */
       const char *p = name + strlen (name);
+#if !defined _GUARDIAN_TARGET
       struct stat st;
+#else
+      struct stat64_post2038 st;
+#endif
       int r;
 
       dir = xmalloc (sizeof (struct directory));
@@ -498,7 +503,7 @@ find_directory (const char *name)
         r = stat (tem, &st);
       }
 #else
-      EINTRLOOP (r, stat (name, &st));
+      EINTRLOOP (r, stat (name, (struct stat *)&st));
 #endif
 
       if (r < 0)

--- a/function.c
+++ b/function.c
@@ -18,6 +18,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include <cextdecs.h>
 #define _XOPEN_SOURCE_EXTENDED 1
 #include <string.h>
+#include "time64.h"
 #endif
 
 #include "makeint.h"
@@ -2109,7 +2110,11 @@ func_realpath (char *o, char **argv, const char *funcname UNUSED)
       if (len < GET_PATH_MAX)
         {
           char *rp;
-          struct stat st;
+#if ! defined _GUARDIAN_TARGET
+	      struct stat st;
+#else
+	      struct stat64_post2038 st;
+#endif
           PATH_VAR (in);
           PATH_VAR (out);
 
@@ -2134,7 +2139,7 @@ func_realpath (char *o, char **argv, const char *funcname UNUSED)
           if (rp)
             {
               int r;
-              EINTRLOOP (r, stat (out, &st));
+              EINTRLOOP (r, stat (out, (struct stat *)&st));
               if (r == 0)
                 {
                   o = variable_buffer_output (o, out, strlen (out));

--- a/output.c
+++ b/output.c
@@ -158,7 +158,7 @@ static void
 set_append_mode (int fd)
 {
 #if defined(F_GETFL) && defined(F_SETFL) && defined(O_APPEND)
-  struct stat stbuf;
+  struct stat stbuf; // Acceptable non-y2038 usage
   int flags;
   if (fstat (fd, &stbuf) != 0 || !S_ISREG (stbuf.st_mode))
     return;
@@ -201,7 +201,7 @@ sync_init (void)
 #else
   if (STREAM_OK (stdout))
     {
-      struct stat stbuf_o, stbuf_e;
+      struct stat stbuf_o, stbuf_e; // acceptable non-y2038 usage
 
       sync_handle = fileno (stdout);
       combined_output = (fstat (fileno (stdout), &stbuf_o) == 0

--- a/read.c
+++ b/read.c
@@ -27,6 +27,9 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include "rule.h"
 #include "debug.h"
 #include "hash.h"
+#ifdef _GUARDIAN_TARGET
+# include "time64.h"
+#endif
 
 
 #ifdef WINDOWS32
@@ -2929,6 +2932,8 @@ construct_include_path (const char **arg_dirs)
 {
 #ifdef VAXC             /* just don't ask ... */
   stat_t stbuf;
+#elif defined _GUARDIAN_TARGET
+  struct stat64_post2038 stbuf;
 #else
   struct stat stbuf;
 #endif
@@ -2969,7 +2974,7 @@ construct_include_path (const char **arg_dirs)
               dir = expanded;
           }
 
-        EINTRLOOP (e, stat (dir, &stbuf));
+        EINTRLOOP (e, stat (dir, (struct stat *)&stbuf));
         if (e == 0 && S_ISDIR (stbuf.st_mode))
           {
             size_t len = strlen (dir);
@@ -3010,7 +3015,7 @@ construct_include_path (const char **arg_dirs)
     {
       int e;
 
-      EINTRLOOP (e, stat (*cpp, &stbuf));
+      EINTRLOOP (e, stat (*cpp, (struct stat *)&stbuf));
       if (e == 0 && S_ISDIR (stbuf.st_mode))
         {
           size_t len = strlen (*cpp);

--- a/time64.h
+++ b/time64.h
@@ -47,7 +47,7 @@ struct  stat64_post2038 {
         uid_t   st_uid;
         gid_t   st_gid;
         dev_t   st_rdev;
-        off64_t   st_size;
+        int64_t   st_size;
         int64_t st_atime;
         int64_t st_mtime;
         int64_t st_ctime;

--- a/vpath.c
+++ b/vpath.c
@@ -20,6 +20,9 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #ifdef WINDOWS32
 #include "pathstuff.h"
 #endif
+#ifdef _GUARDIAN_TARGET
+# include "time64.h"
+#endif
 #include "debug.h"
 
 
@@ -494,7 +497,7 @@ selective_vpath_search (struct vpath *path, const char *file,
 #ifdef _GUARDIAN_TARGET
       if ( 1 ) /* stat below will check this */
         {
-          struct stat st;
+          struct stat64_post2038 st;
 
           exists_in_cache = 1; /* force stat */
 #else
@@ -524,7 +527,7 @@ selective_vpath_search (struct vpath *path, const char *file,
             {
               int e;
 
-              EINTRLOOP (e, stat (name, &st)); /* Does it really exist?  */
+              EINTRLOOP (e, stat (name, (struct stat *)&st)); /* Does it really exist?  */
               if (e != 0)
                 {
                   exists = 0;


### PR DESCRIPTION
This change includes handling AR Epoch 1 internal timestamp writing on touch and replacing lstat with stat in remake, which is safe in Guardian because there are no links in Guardian. The manual has also been updated.

Fixes: #96
